### PR TITLE
Fix Linux CI Homebrew sandbox setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,11 @@ jobs:
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
+
+      - name: Install Bubblewrap
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y bubblewrap
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
         with:
           core: false
           cask: false


### PR DESCRIPTION
## Summary

Fix the Linux Homebrew test-bot setup failure caused by a missing Bubblewrap executable, and update deprecated Homebrew setup action references.

## Changes

- Install `bubblewrap` before running `brew test-bot` on Linux CI runners.
- Update `Homebrew/actions/setup-homebrew` from `master` to `main` in CI and publish workflows.

## Validation

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "OK #{f}" }' .github/workflows/ci.yml .github/workflows/publish.yml`

## Summary by Sourcery

更新 CI 工作流以使用 Homebrew setup action 的 main 分支，并确保在运行 Homebrew 测试前，Linux runner 会安装 Bubblewrap。

CI：
- 将 CI 和发布工作流中使用的 Homebrew/actions/setup-homebrew 从已废弃的 master 分支切换为 main 分支。
- 在执行 `brew test-bot` 之前，在 Linux CI runner 上安装 bubblewrap 软件包，以防止沙箱（sandbox）设置失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update CI workflows to use the main branch of the Homebrew setup action and ensure Linux runners install Bubblewrap before running Homebrew tests.

CI:
- Switch Homebrew/actions/setup-homebrew usage from the deprecated master branch to the main branch in CI and publish workflows.
- Install the bubblewrap package on Linux CI runners before executing brew test-bot to prevent sandbox setup failures.

</details>