### PR TITLE
maa-cli 0.7.5

### DIFF
--- a/Formula/maa-cli-beta.rb
+++ b/Formula/maa-cli-beta.rb
@@ -1,21 +1,13 @@
 class MaaCliBeta < Formula
   desc "Command-line tool for MAA (MaaAssistantArknights)"
   homepage "https://github.com/MaaAssistantArknights/maa-cli/"
-  url "https://github.com/MaaAssistantArknights/maa-cli/archive/refs/tags/v0.7.4.tar.gz"
-  sha256 "21979d35ecb5a3a617e2e8b89acd4e9de1256b8f44c07ae63f6d4773bfee161f"
+  url "https://github.com/MaaAssistantArknights/maa-cli/archive/refs/tags/v0.7.5.tar.gz"
+  sha256 "3f288b98e783a4ff230982d5c235c179ccc97617b7da1fe61f6766412ea6badd"
   license "AGPL-3.0-only"
 
   livecheck do
     url :stable
     regex(/^v?(\d+\.\d+\.\d+(?:-(?:beta|rc)\.\d+)?)$/i)
-  end
-
-  bottle do
-    root_url "https://github.com/MaaAssistantArknights/homebrew-tap/releases/download/maa-cli-beta-0.7.4"
-    sha256 cellar: :any,                 arm64_tahoe:   "21861f63460cde7ede99ac9d25934cf5903e25d3cee6c9e8208f1b98a33fee35"
-    sha256 cellar: :any,                 arm64_sequoia: "8aa217948e1305cfab2e786b564be38146d5df7f580237e9e8b60a0e286f200b"
-    sha256 cellar: :any,                 arm64_sonoma:  "c9a6dbde65639580054185e32fc00f92c518a623df4559a8dfe65cafe14b1e88"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "38fa12aad452dbe557effa66a7026a0a115b7e91531ca2a90dd837898253abf1"
   end
 
   option "without-git2", "Don't build with libgit2 resource updater backend"
@@ -44,7 +36,13 @@ class MaaCliBeta < Formula
 
     system "cargo", "install", "--no-default-features",
       "--features", features.join(","), *std_cargo_args(path: package_path)
-    fish_completion.install "#{package_path}/completions/maa.fish"
+    {
+      bash_completion/"maa"      => "bash",
+      zsh_completion/"_maa"      => "zsh",
+      fish_completion/"maa.fish" => "fish",
+    }.each do |completion, shell|
+      completion.write Utils.safe_popen_read({ "MAA_COMPLETE" => shell }, bin/"maa")
+    end
   end
 
   test do

--- a/Formula/maa-cli-beta.rb
+++ b/Formula/maa-cli-beta.rb
@@ -10,6 +10,14 @@ class MaaCliBeta < Formula
     regex(/^v?(\d+\.\d+\.\d+(?:-(?:beta|rc)\.\d+)?)$/i)
   end
 
+  bottle do
+    root_url "https://github.com/MaaAssistantArknights/homebrew-tap/releases/download/maa-cli-beta-0.7.5"
+    sha256 cellar: :any, arm64_tahoe:   "974f7f9a2e2ef949dee6bacb85c1b77d2306f66f7473a9cf4b9e14432551a615"
+    sha256 cellar: :any, arm64_sequoia: "3fa01e966bd32acaa4fa24055997ca34d5375efc3a2a536c8cc18a2daa18b5b1"
+    sha256 cellar: :any, arm64_sonoma:  "bf3668286eb5cafb843e333ab814989ce2910c3d5a891bfa943698b08cd047f8"
+    sha256 cellar: :any, x86_64_linux:  "5a9e9d592f704be7352e3542a9fc32ce5bef4d04667393b524acd3a663cacce4"
+  end
+
   option "without-git2", "Don't build with libgit2 resource updater backend"
   option "without-core-installer", "Don't build with core installer"
 

--- a/Formula/maa-cli.rb
+++ b/Formula/maa-cli.rb
@@ -10,6 +10,14 @@ class MaaCli < Formula
     regex(/^v?(\d+\.\d+\.\d+)$/i)
   end
 
+  bottle do
+    root_url "https://github.com/MaaAssistantArknights/homebrew-tap/releases/download/maa-cli-0.7.5"
+    sha256 cellar: :any, arm64_tahoe:   "639d5e59f28610580d160d1a8751fa8761314914ebc873cfff43d8539b2a7627"
+    sha256 cellar: :any, arm64_sequoia: "471dcc7638f0cad42a43fd109d8e66ffafab8a1c0b0a27ce1f98cca23d2d7863"
+    sha256 cellar: :any, arm64_sonoma:  "2f045ea4f9414a83f0ca6783d16e2b07b62b7d58ba6eee4d395100ebc04a428c"
+    sha256 cellar: :any, x86_64_linux:  "1ac0364c638a66df78a53480b2e4db18d9ea996c8d9dfa9b4067575d6450a459"
+  end
+
   option "without-git2", "Don't build with libgit2 resource updater backend"
   option "without-core-installer", "Don't build with core installer"
 

--- a/Formula/maa-cli.rb
+++ b/Formula/maa-cli.rb
@@ -1,21 +1,13 @@
 class MaaCli < Formula
   desc "Command-line tool for MAA (MaaAssistantArknights)"
   homepage "https://github.com/MaaAssistantArknights/maa-cli/"
-  url "https://github.com/MaaAssistantArknights/maa-cli/archive/refs/tags/v0.7.4.tar.gz"
-  sha256 "21979d35ecb5a3a617e2e8b89acd4e9de1256b8f44c07ae63f6d4773bfee161f"
+  url "https://github.com/MaaAssistantArknights/maa-cli/archive/refs/tags/v0.7.5.tar.gz"
+  sha256 "3f288b98e783a4ff230982d5c235c179ccc97617b7da1fe61f6766412ea6badd"
   license "AGPL-3.0-only"
 
   livecheck do
     url :stable
     regex(/^v?(\d+\.\d+\.\d+)$/i)
-  end
-
-  bottle do
-    root_url "https://github.com/MaaAssistantArknights/homebrew-tap/releases/download/maa-cli-0.7.4"
-    sha256 cellar: :any,                 arm64_tahoe:   "815f239ca2dc3efcfa9767bdc6065eaa74a9c2cf37f13926ebfed2bcfcad15fe"
-    sha256 cellar: :any,                 arm64_sequoia: "c647ce4e9d63e7a43e0e974fcd96786c6b839f184e2eb39da7601ca593caae4b"
-    sha256 cellar: :any,                 arm64_sonoma:  "dde4ec9b33e5711deb2adb8d81d949a88a71883d1315407729bdf3fd37a55139"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "bc7b5d80d9472d1e078b992aa4aa759b54c2761df61e086d169d3a4c36b75f81"
   end
 
   option "without-git2", "Don't build with libgit2 resource updater backend"
@@ -45,7 +37,13 @@ class MaaCli < Formula
 
     system "cargo", "install", "--no-default-features",
       "--features", features.join(","), *std_cargo_args(path: package_path)
-    fish_completion.install "#{package_path}/completions/maa.fish"
+    {
+      bash_completion/"maa"      => "bash",
+      zsh_completion/"_maa"      => "zsh",
+      fish_completion/"maa.fish" => "fish",
+    }.each do |completion, shell|
+      completion.write Utils.safe_popen_read({ "MAA_COMPLETE" => shell }, bin/"maa")
+    end
   end
 
   test do


### PR DESCRIPTION
## Summary

Combine the maa-cli and maa-cli-beta 0.7.5 bumps and update completion installation for the new dynamic completion generation path.

## Changes

- Bump `maa-cli` and `maa-cli-beta` to v0.7.5.
- Generate bash, zsh, and fish completions with `MAA_COMPLETE=<shell> maa` instead of installing the removed static fish completion file.
- Drop stale 0.7.4 bottle blocks so the bumped formulae do not point at old bottle metadata.

## Validation

- `ruby -c Formula/maa-cli.rb`
- `ruby -c Formula/maa-cli-beta.rb`
- `brew style Formula/maa-cli.rb Formula/maa-cli-beta.rb`
- `brew audit --strict --online maa-cli maa-cli-beta`

Closes #672, closes #673 

## 由 Sourcery 提供的摘要

将 maa-cli 和 maa-cli-beta 的 Homebrew 配方版本提升到 0.7.5，并使 shell 补全处理方式与工具新的动态补全机制保持一致。

增强内容：
- 将 maa-cli 和 maa-cli-beta 配方源更新至 v0.7.5，并移除过时的 bottle 元数据。
- 将 bash、zsh 和 fish 的补全安装切换为使用由 maa 可执行文件动态生成的补全，而不是依赖静态的 fish 补全文件。