### PR TITLE
Drop Intel macOS CI bottling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
         os:
           - ubuntu-22.04
           - macos-14
-          - macos-15-intel
           - macos-15
           - macos-26
     steps:

--- a/README.md
+++ b/README.md
@@ -49,10 +49,6 @@ Due to the limitation of Homebrew and GitHub Action runner, we only provide preb
             <td>aarch64 (Apple Silicon)</td>
         </tr>
         <tr>
-            <td>macOS 15 (Sequoia)</td>
-            <td>x86_64 (Intel)</td>
-        </tr>
-        <tr>
             <td>macOS 14 (Sonoma)</td>
             <td>aarch64 (Apple Silicon)</td>
         </tr>


### PR DESCRIPTION
Remove the Intel macOS CI runner and stop advertising Intel macOS bottle support in the README. The current GitHub-hosted Intel runner is Sequoia, while key build dependencies such as rust are only bottled for Intel Sonoma in Homebrew/core, so this job only validates syntax and cannot produce a bottle.

## 由 Sourcery 提供的总结

从 CI 和已记录的预编译二进制矩阵中移除对 Intel macOS 15（Sequoia）的支持。

CI：
- 从 GitHub Actions 工作流矩阵中移除 Intel macOS 15（Sequoia）的 CI 任务。

文档：
- 在 README 的平台支持矩阵中，不再宣称支持 Intel macOS 15（Sequoia）预编译 bottle。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Drop Intel macOS 15 (Sequoia) support from CI and documented prebuilt binaries matrix.

CI:
- Remove the Intel macOS 15 (Sequoia) CI job from the GitHub Actions workflow matrix.

Documentation:
- Stop advertising Intel macOS 15 (Sequoia) prebuilt bottle support in the README platform matrix.

</details>