### PR TITLE
Fix trusted workflow_run publish gating

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-      issues: write
       pull-requests: read
     outputs:
       publish: ${{ steps.check.outputs.publish }}
@@ -161,13 +160,7 @@ jobs:
                 return;
               }
 
-              await github.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number: number,
-                labels: ['Automerge'],
-              });
-              core.notice(`Added Automerge to trusted autobump PR #${number}.`);
+              core.notice(`Trusted autobump PR #${number} passed CI; continuing without requiring Automerge.`);
             }
 
             core.setOutput('publish', 'true');


### PR DESCRIPTION
Stop trying to add the Automerge label from the trusted workflow_run path. The workflow_run GITHUB_TOKEN can read PR state and continue publishing, but adding labels from that path is failing with "Resource not accessible by integration". Manual publish still requires the Automerge label via pull_request_target; trusted same-repo bump PRs now proceed directly after CI succeeds.

## Summary by Sourcery

Bug Fixes:
- 停止在 `workflow_run` 任务中添加 `Automerge` 标签，以避免权限错误，同时仍然允许可信的发布流程继续进行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Stop adding the Automerge label from workflow_run jobs to avoid permission errors while still allowing trusted publish to proceed.

</details>