### PR TITLE
Use main for git-try-push action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -237,7 +237,7 @@ jobs:
             "$PR"
 
       - name: Push commits to PR branch
-        uses: Homebrew/actions/git-try-push@master
+        uses: Homebrew/actions/git-try-push@main
         with:
           token: ${{ github.token }}
           branch: ${{ needs.check.outputs.head_ref }}


### PR DESCRIPTION
Update the deprecated `Homebrew/actions/git-try-push@master` reference to `Homebrew/actions/git-try-push@main` in `publish.yml`.