### PR TITLE
fix: Bump livecheck watchlist handling

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -44,10 +44,25 @@ jobs:
         env:
           BUMP_WATCHLIST: "/opt/homebrew/Library/Taps/maaassistantarknights/homebrew-tap/auto_bump/${{ matrix.type }}.txt"
         run: |
+          if [[ ! -f "$BUMP_WATCHLIST" ]]; then
+            echo "::error::Bump watchlist not found: $BUMP_WATCHLIST"
+            exit 1
+          fi
+
           packages=()
-          while IFS= read -r package; do
+          while IFS= read -r package || [[ -n "$package" ]]; do
+            package="${package%%#*}"
+            package="${package#"${package%%[![:space:]]*}"}"
+            package="${package%"${package##*[![:space:]]}"}"
+            [[ -n "$package" ]] || continue
+
             packages+=("maaassistantarknights/tap/${package}")
           done < "$BUMP_WATCHLIST"
+
+          if (( ${#packages[@]} == 0 )); then
+            echo "::error::Bump watchlist contains no package entries: $BUMP_WATCHLIST"
+            exit 1
+          fi
 
           livecheck_result="$(brew livecheck --newer-only --${{ matrix.type }} --json "${packages[@]}")"
           echo "$livecheck_result"

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -42,13 +42,17 @@ jobs:
 
       - name: Livecheck
         env:
-          HOMEBREW_LIVECHECK_WATCHLIST: "/opt/homebrew/Library/Taps/maaassistantarknights/homebrew-tap/auto_bump/${{ matrix.type }}.txt"
+          BUMP_WATCHLIST: "/opt/homebrew/Library/Taps/maaassistantarknights/homebrew-tap/auto_bump/${{ matrix.type }}.txt"
         run: |
-          brew livecheck --newer-only --${{ matrix.type }} --json
-          {
-            echo -n "LIVECHECK_RESULT="
-            brew livecheck --newer-only --${{ matrix.type }} --json | jq -c '.'
-          } >> "$GITHUB_ENV"
+          packages=()
+          while IFS= read -r package; do
+            packages+=("maaassistantarknights/tap/${package}")
+          done < "$BUMP_WATCHLIST"
+
+          livecheck_result="$(brew livecheck --newer-only --${{ matrix.type }} --json "${packages[@]}")"
+          echo "$livecheck_result"
+          compact_result="$(jq -c '.' <<< "$livecheck_result")"
+          echo "LIVECHECK_RESULT=$compact_result" >> "$GITHUB_ENV"
 
       - name: Auto Bump
         uses: actions/github-script@v8

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -77,13 +77,31 @@ jobs:
           script: |
             const info = JSON.parse(process.env.LIVECHECK_RESULT);
             const type = `${{ matrix.type }}`;
+            const dryRun = context.eventName === 'push';
             for (let i = 0; i < info.length; i++) {
               const name = info[i][type];
               const version = info[i].version.latest;
-              core.info(`Bumping \`${name}\` to \`${version}\``);
+              const branchVersion = type === 'cask' ? version.replace(/[,:]/g, '-') : version;
+              const branch = `bump-${name}-${branchVersion}`;
+
+              if (!dryRun) {
+                try {
+                  await github.rest.git.getRef({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    ref: `heads/${branch}`
+                  });
+                  core.info(`Skipping \`${name}\` because branch \`${branch}\` already exists`);
+                  continue;
+                } catch (error) {
+                  if (error.status !== 404) throw error;
+                }
+              }
+
+              core.info(`${dryRun ? 'Dry-running bump of' : 'Bumping'} \`${name}\` to \`${version}\``);
 
               try {
-                await exec.exec('brew', [
+                const args = [
                   `bump-${type}-pr`,
                   `maaassistantarknights/tap/${name}`,
                   '--no-audit',
@@ -91,7 +109,9 @@ jobs:
                   '--no-fork',
                   `--version=${version}`,
                   `--message=Bump \`${name}\` to \`${version}\``
-                ]);
+                ];
+                if (dryRun) args.push('--dry-run');
+                await exec.exec('brew', args);
               } catch (error) {
                 core.setFailed(`Failed to bump ${name}: ${error.message}`);
               }


### PR DESCRIPTION
## Summary

Fix scheduled Bump runs after Homebrew 6 changed no-argument `brew livecheck` to evaluate all trusted formulae and casks instead of honoring this tap watchlist.

## Changes

- Read each matrix watchlist and pass fully qualified tap entries as explicit `brew livecheck` arguments.
- Run livecheck once and reuse its compact JSON result for the Auto Bump step.

## Validation

- `actionlint .github/workflows/bump.yml`
- Formula livecheck probe for `maa-cli` and `maa-cli-beta` (returned `[]`)
- Cask livecheck probe for `maa@beta` and `playcover-maa` (returned only those two entries)
- `./bin/brew lgtm`

## Summary by Sourcery

CI：
- 调整 bump 工作流程，以读取观察列表（watchlists），将完全限定的 tap 软件包名称传递给 `brew livecheck`，并通过 `GITHUB_ENV` 导出其精简的 JSON 输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Adjust bump workflow to read watchlists, pass fully qualified tap package names to brew livecheck, and export its compact JSON output via GITHUB_ENV.

</details>